### PR TITLE
Success

### DIFF
--- a/714_Best_Time_to_Buy_and_Sell_Stock_with_Transaction_Fee.go
+++ b/714_Best_Time_to_Buy_and_Sell_Stock_with_Transaction_Fee.go
@@ -1,0 +1,22 @@
+package leetcode
+
+/*
+Success
+Details
+Runtime: 88 ms, faster than 67.50% of Go online submissions for Best Time to Buy and Sell Stock with Transaction Fee.
+Memory Usage: 8.3 MB, less than 40.00% of Go online submissions for Best Time to Buy and Sell Stock with Transaction Fee.
+*/
+func maxProfitWithFree(prices []int, fee int) int {
+	bestBuy := 0
+	profit := 0
+	for i := 0; i < len(prices); i++ {
+		if i == 0 {
+			bestBuy = -prices[i]
+		} else {
+			newBestBuy := -prices[i] + profit
+			bestBuy = max(bestBuy, newBestBuy)
+		}
+		profit = max(profit, bestBuy+prices[i]-fee)
+	}
+	return profit
+}

--- a/714_Best_Time_to_Buy_and_Sell_Stock_with_Transaction_Fee_test.go
+++ b/714_Best_Time_to_Buy_and_Sell_Stock_with_Transaction_Fee_test.go
@@ -1,0 +1,32 @@
+package leetcode
+
+import "testing"
+
+func Test_maxProfitWithFree(t *testing.T) {
+	type args struct {
+		prices []int
+		fee    int
+	}
+	tests := []struct {
+		name string
+		args args
+		want int
+	}{
+		// TODO: Add test cases.
+		{
+			name: "case 1",
+			args: args{
+				prices: []int{1, 3, 2, 8, 4, 9},
+				fee:    2,
+			},
+			want: 8,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := maxProfitWithFree(tt.args.prices, tt.args.fee); got != tt.want {
+				t.Errorf("maxProfitWithFree() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Details
Runtime: 88 ms, faster than 67.50% of Go online submissions for Best Time to Buy and Sell Stock with Transaction Fee.
Memory Usage: 8.3 MB, less than 40.00% of Go online submissions for Best Time to Buy and Sell Stock with Transaction Fee.